### PR TITLE
Skip bp_dialog_timeout events for Botpress NLU

### DIFF
--- a/modules/botpress-nlu/README.md
+++ b/modules/botpress-nlu/README.md
@@ -63,6 +63,8 @@ Botpress NLU will instrument incoming events by providing a standardized object 
 | `nlu.sentiment` | TBD | - |
 | `nlu.language` | TBD | - |
 
+Botpress NLU also provide convenient functions to the nlu object : `nlu.intent.is(intentName)` and `nlu.intents.has(intentName)`.
+
 # Providers – Features Matrix
 
 | Provider | Synchronization | Intent Classification | Entity Extraction | Scopes (*coming soon*) |

--- a/modules/botpress-nlu/src/index.js
+++ b/modules/botpress-nlu/src/index.js
@@ -70,6 +70,8 @@ module.exports = {
     }
 
     async function incomingMiddleware(event, next) {
+      if (event.type === 'bp_dialog_timeout') return next()
+
       try {
         const metadata = await retry(() => provider.extract(event), retryPolicy)
         if (metadata) {


### PR DESCRIPTION
bp_dialog_timeout events are polluting nlp providers analytics and increasing number of requests and thus quota limit