### PR TITLE
Skill choice depends on content not plain text

### DIFF
--- a/skills/botpress-skill-choice/package.json
+++ b/skills/botpress-skill-choice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/skill-choice",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "description": "Botpress Skill that allows users to pick an option",
   "main": "bin/node.bundle.js",
   "homepage": "https://github.com/botpress/modules",
@@ -22,7 +22,7 @@
   "author": "Botpress Team",
   "license": "Botpress Proprietary License",
   "peerDependencies": {
-    "botpress": ">= 10.0.0"
+    "botpress": ">= 10.0.10"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/skills/botpress-skill-choice/webpack.js
+++ b/skills/botpress-skill-choice/webpack.js
@@ -45,7 +45,8 @@ var webConfig = {
     'react': 'React',
     'react-dom': 'ReactDOM',
     'react-bootstrap': 'ReactBootstrap',
-    'prop-types': 'PropTypes'
+    'prop-types': 'PropTypes',
+    'botpress/content-picker': 'BotpressContentPicker',
   },
   resolve: {
     extensions: ['.js', '.jsx']


### PR DESCRIPTION
Depends on https://github.com/botpress/botpress/pull/524
NOT READY FOR MERGE YET

It currently looks like this:
<img src="https://user-images.githubusercontent.com/1932290/38277380-e346109a-37a0-11e8-9301-6276ecd5570e.png" height="300"> <img src="https://user-images.githubusercontent.com/1932290/38277291-9538b290-37a0-11e8-8e61-61e53545cbf6.png"  height="300">
Note, that red text-area only gets displayed if user has saved plain-text not content-item (so that he can create content-item based on it).

@slvnperron , I've made selecting content-items work for question and "invalid answer", but not ready with choices yet. Could you review whether overall approach makes sense? As for choices, not sure how to implement it in terms of UI/UX:
1. It won't work on enter as it is now. So it looks I'll need an "Add" button, right?
2. Will user be able to select different content-items for existing choices, or will he need to delete them and add new ones?
3. Will we need to generate keywords based on all the translations not just one? Will user be able to edit them in the same way as he is able now?