### PR TITLE
Analytics: countUniq content-type

### DIFF
--- a/functionals/botpress-analytics/package.json
+++ b/functionals/botpress-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/analytics",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "description": "Provides high level analytics about your bot usage.",
   "main": "bin/node.bundle.js",
   "homepage": "https://github.com/botpress/modules",

--- a/functionals/botpress-analytics/src/views/custom.jsx
+++ b/functionals/botpress-analytics/src/views/custom.jsx
@@ -135,10 +135,6 @@ export default class CustomMetrics extends React.Component {
       metrics: [],
       range: 'thisweek'
     }
-
-    this.render_count = this.render_count.bind(this)
-    this.render_percent = this.render_percent.bind(this)
-    this.render_piechart = this.render_piechart.bind(this)
   }
 
   componentDidMount() {
@@ -188,7 +184,7 @@ export default class CustomMetrics extends React.Component {
     return _.sortBy(data, ['name'])
   }
 
-  render_count(metric) {
+  render_count = (metric) => {
     const data = this.mergeDataWithDates(
       metric.results.map(row => {
         return { name: row.date, value: row.count }
@@ -209,7 +205,7 @@ export default class CustomMetrics extends React.Component {
     return (
       <div>
         <div className={style.customCount} style={{ height: '50px' }}>
-          {sum}
+          {metric.countUniq || sum}
         </div>
         <div className={style.customCountSmall} style={{ height: '25px' }}>
           Avg {avgPerDay} ({absAvg})
@@ -223,7 +219,9 @@ export default class CustomMetrics extends React.Component {
     )
   }
 
-  render_percent(metric) {
+  render_countUniq = (metric) => this.render_count(metric)
+
+  render_percent = (metric) => {
     const data = this.mergeDataWithDates(
       metric.results.map(row => {
         return { name: row.date, value: row.percent }
@@ -258,7 +256,7 @@ export default class CustomMetrics extends React.Component {
     )
   }
 
-  render_piechart(metric) {
+  render_piechart = (metric) => {
     const data = metric.results.map(row => {
       return { name: row.name, value: row.count }
     })


### PR DESCRIPTION
This is intended to handle the use-case when we want to display number of uniq records (e.g. number of unique active users).